### PR TITLE
Fixes #10258

### DIFF
--- a/app/views/layouts/_errorMessages.html.erb
+++ b/app/views/layouts/_errorMessages.html.erb
@@ -1,6 +1,6 @@
 <% if model.errors.any? %>
 <div class="alert alert-danger">
-  <h2><%= pluralize(model.errors.count,"error")%> prohibited this <%= model.class.to_s.downcase %> from being saved </h2>
+  <h2><%= translation('errors.template.header.other', :count => model.errors.count, :model => model.class.to_s.downcase) %></h2>
     <ul>
       <% model.errors.full_messages.each do |msg|%>
         <li><%= msg %></li>


### PR DESCRIPTION
Update the file _errorMessages.html.erb in the Plot2 repository and edit the line as shown below.

Remove this line:
<h2><%= pluralize(model.errors.count,"error")%> prohibited this <%= model.class.to_s.downcase %> from being saved </h2>

Added this line
<h2><%= translation('errors.template.header.other', :count => model.errors.count, :model => model.class.to_s.downcase) %></h2>